### PR TITLE
[06][test]案件管理CRUDテスト追加

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -23,7 +23,8 @@
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="BROADCAST_CONNECTION" value="null"/>
         <env name="CACHE_STORE" value="array"/>
-        <env name="DB_DATABASE" value="testing"/>
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="QUEUE_CONNECTION" value="sync"/>
         <env name="SESSION_DRIVER" value="array"/>

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Contracts\Console\Kernel;
+
+trait CreatesApplication
+{
+    /**
+     * Creates the application.
+     */
+    public function createApplication()
+    {
+        $app = require __DIR__.'/../bootstrap/app.php';
+
+        $app->make(Kernel::class)->bootstrap();
+
+        return $app;
+    }
+}

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -10,7 +10,7 @@ class ExampleTest extends TestCase
     /**
      * A basic test example.
      */
-    public function test_the_application_returns_a_successful_response(): void
+    public function test_homepage_request_can_return_successful_response(): void
     {
         $response = $this->get('/');
 

--- a/tests/Feature/ProjectCrudTest.php
+++ b/tests/Feature/ProjectCrudTest.php
@@ -76,7 +76,7 @@ class ProjectCrudTest extends TestCase
         $response->assertSee('問い合わせ');
     }
 
-    public function test_edit_with_project_can_show_and_missing_can_return_404(): void
+    public function test_edit_with_project_can_show(): void
     {
         $primitives = [
             'id' => 10,
@@ -86,16 +86,21 @@ class ProjectCrudTest extends TestCase
             'status' => 'contact',
         ];
 
-        // success case
         $this->app->bind(\App\Domain\Repositories\ProjectRepositoryInterface::class, fn () => $this->makeInMemoryRepository([$primitives]));
+
         $res = $this->get(route('projects.edit', $primitives['id']));
+
         $res->assertStatus(200);
         $res->assertSee('Edit Me');
+    }
 
-        // not found case
+    public function test_edit_missing_can_return_404(): void
+    {
         $this->app->bind(\App\Domain\Repositories\ProjectRepositoryInterface::class, fn () => $this->makeInMemoryRepository([]));
-        $res2 = $this->get(route('projects.edit', 9999));
-        $res2->assertStatus(404);
+
+        $res = $this->get(route('projects.edit', 9999));
+
+        $res->assertStatus(404);
     }
 
     public function test_destroy_with_missing_can_return_404(): void

--- a/tests/Feature/ProjectCrudTest.php
+++ b/tests/Feature/ProjectCrudTest.php
@@ -1,0 +1,253 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Application\ViewModels\ProjectViewModel;
+use Tests\TestCase;
+
+class ProjectCrudTest extends TestCase
+{
+    private function fakeCreateUseCase()
+    {
+        return new class
+        {
+            public function execute($dto)
+            {
+                return null;
+            }
+        };
+    }
+
+    private function fakeUpdateUseCase()
+    {
+        return new class
+        {
+            public function execute($dto)
+            {
+                return null;
+            }
+        };
+    }
+
+    private function fakeDeleteUseCase()
+    {
+        return new class
+        {
+            public function execute(int $id): void {}
+        };
+    }
+
+    private function fakeGetUseCase(?array $primitives = null)
+    {
+        return new class($primitives)
+        {
+            private $p;
+            public function __construct($p)
+            {
+                $this->p = $p;
+            }
+            public function execute(int $id)
+            {
+                if (! $this->p) {
+                    return null;
+                }
+
+                return ProjectViewModel::fromPrimitives($this->p);
+            }
+        };
+    }
+
+    private function fakeListUseCase(array $items = [])
+    {
+        return new class($items)
+        {
+            private $items;
+            public function __construct($items)
+            {
+                $this->items = $items;
+            }
+            public function execute(int $perPage = 10)
+            {
+                $collection = collect($this->items);
+
+                return new \Illuminate\Pagination\LengthAwarePaginator($collection, $collection->count(), $perPage);
+            }
+        };
+    }
+
+    private function makeInMemoryRepository(array $items = [])
+    {
+        return new class($items) implements \App\Domain\Repositories\ProjectRepositoryInterface
+        {
+            private $items;
+            public function __construct($items = [])
+            {
+                $this->items = $items;
+            }
+
+            public function save(\App\Domain\Models\Project $project): \App\Domain\Models\Project
+            {
+                return $project;
+            }
+
+            public function findById(int $id): ?\App\Domain\Models\Project
+            {
+                foreach ($this->items as $p) {
+                    if (isset($p['id']) && (int) $p['id'] === $id) {
+                        return \App\Domain\Models\Project::fromPrimitives($p);
+                    }
+                }
+
+                return null;
+            }
+
+            public function paginate(int $perPage = 10): \Illuminate\Contracts\Pagination\Paginator
+            {
+                $domain = collect($this->items)->map(fn ($p) => \App\Domain\Models\Project::fromPrimitives($p));
+
+                return new \Illuminate\Pagination\LengthAwarePaginator($domain, $domain->count(), $perPage);
+            }
+
+            public function delete(int $id): void
+            {
+                // noop
+            }
+        };
+    }
+
+    public function test_index_displays_projects(): void
+    {
+        $pr = [
+            'id' => 1,
+            'title' => 'My Project Title',
+            'client_name' => 'Client A',
+            'unit_price' => 1000,
+            'start_date' => '2026-01-01',
+            'end_date' => '2026-01-05',
+            'status' => 'working',
+            'memo' => 'note',
+        ];
+
+        $this->app->bind(\App\Domain\Repositories\ProjectRepositoryInterface::class, fn () => $this->makeInMemoryRepository([$pr]));
+
+        $response = $this->get(route('projects.index'));
+
+        $response->assertStatus(200);
+        $response->assertSee('My Project Title');
+        $response->assertSee('Client A');
+    }
+
+    public function test_create_displays_form(): void
+    {
+        $response = $this->get(route('projects.create'));
+
+        $response->assertStatus(200);
+        $response->assertSee('問い合わせ');
+    }
+
+    public function test_edit_shows_project_and_404_when_missing(): void
+    {
+        $primitives = [
+            'id' => 10,
+            'title' => 'Edit Me',
+            'client_name' => 'Client E',
+            'unit_price' => 1500,
+            'status' => 'contact',
+        ];
+
+        // success case
+        $this->app->bind(\App\Domain\Repositories\ProjectRepositoryInterface::class, fn () => $this->makeInMemoryRepository([$primitives]));
+        $res = $this->get(route('projects.edit', $primitives['id']));
+        $res->assertStatus(200);
+        $res->assertSee('Edit Me');
+
+        // not found case
+        $this->app->bind(\App\Domain\Repositories\ProjectRepositoryInterface::class, fn () => $this->makeInMemoryRepository([]));
+        $res2 = $this->get(route('projects.edit', 9999));
+        $res2->assertStatus(404);
+    }
+
+    public function test_destroy_returns_404_when_missing(): void
+    {
+        $this->app->bind(\App\Domain\Repositories\ProjectRepositoryInterface::class, fn () => $this->makeInMemoryRepository([]));
+
+        $res = $this->delete(route('projects.destroy', 9999));
+        $res->assertStatus(404);
+    }
+
+    public function test_store_creates_project(): void
+    {
+        $this->app->bind(\App\Domain\Repositories\ProjectRepositoryInterface::class, fn () => $this->makeInMemoryRepository());
+
+        $data = [
+            'title' => 'New Project',
+            'client_name' => 'Client B',
+            'unit_price' => 5000,
+            'start_date' => '2026-02-01',
+            'end_date' => '2026-02-10',
+            'status' => 'contact',
+            'memo' => 'created by test',
+        ];
+
+        $response = $this->post(route('projects.store'), $data);
+
+        $response->assertRedirect(route('projects.index'));
+    }
+
+    public function test_store_validation_fails_can_return_errors(): void
+    {
+        $this->app->bind(\App\Domain\Repositories\ProjectRepositoryInterface::class, fn () => $this->makeInMemoryRepository());
+
+        $data = [
+            'title' => '',
+            'client_name' => '',
+            'unit_price' => -1,
+            'status' => 'invalid_status',
+        ];
+
+        $response = $this->post(route('projects.store'), $data);
+
+        $response->assertSessionHasErrors(['title', 'client_name', 'unit_price', 'status']);
+    }
+
+    public function test_update_updates_project(): void
+    {
+        $primitives = [
+            'id' => 2,
+            'title' => 'Old Title',
+            'client_name' => 'Client C',
+            'unit_price' => 1000,
+            'status' => 'contact',
+        ];
+
+        $this->app->bind(\App\Domain\Repositories\ProjectRepositoryInterface::class, fn () => $this->makeInMemoryRepository([$primitives]));
+
+        $update = [
+            'title' => 'Updated Title',
+            'client_name' => 'Client C',
+            'unit_price' => 2000,
+            'status' => 'working',
+        ];
+
+        $response = $this->put(route('projects.update', $primitives['id']), $update);
+
+        $response->assertRedirect(route('projects.index'));
+    }
+
+    public function test_destroy_deletes_project(): void
+    {
+        $primitives = [
+            'id' => 3,
+            'title' => 'To Delete',
+            'client_name' => 'Client D',
+            'unit_price' => 1000,
+            'status' => 'contact',
+        ];
+
+        $this->app->bind(\App\Domain\Repositories\ProjectRepositoryInterface::class, fn () => $this->makeInMemoryRepository([$primitives]));
+
+        $response = $this->delete(route('projects.destroy', $primitives['id']));
+
+        $response->assertRedirect(route('projects.index'));
+    }
+}

--- a/tests/Feature/ProjectCrudTest.php
+++ b/tests/Feature/ProjectCrudTest.php
@@ -186,4 +186,98 @@ class ProjectCrudTest extends TestCase
 
         $response->assertRedirect(route('projects.index'));
     }
+
+    public function test_update_validation_fails_can_return_errors(): void
+    {
+        $primitives = [
+            'id' => 4,
+            'title' => 'Will Fail',
+            'client_name' => 'Client X',
+            'unit_price' => 1000,
+            'status' => 'contact',
+        ];
+
+        $this->app->bind(\App\Domain\Repositories\ProjectRepositoryInterface::class, fn () => $this->makeInMemoryRepository([$primitives]));
+
+        $data = [
+            'title' => '',
+            'client_name' => '',
+            'unit_price' => -10,
+            'status' => 'not_a_status',
+        ];
+
+        $response = $this->put(route('projects.update', $primitives['id']), $data);
+
+        $response->assertSessionHasErrors(['title', 'client_name', 'unit_price', 'status']);
+    }
+
+    public function test_store_with_invalid_date_format_and_order_returns_errors(): void
+    {
+        $this->app->bind(\App\Domain\Repositories\ProjectRepositoryInterface::class, fn () => $this->makeInMemoryRepository());
+
+        // invalid format
+        $data1 = [
+            'title' => 'Dated',
+            'client_name' => 'Client D',
+            'unit_price' => 1000,
+            'start_date' => 'not-a-date',
+            'end_date' => '2026-02-02',
+            'status' => 'contact',
+        ];
+
+        $res1 = $this->post(route('projects.store'), $data1);
+        $res1->assertSessionHasErrors(['start_date']);
+
+        // end_date before start_date
+        $data2 = [
+            'title' => 'Bad Order',
+            'client_name' => 'Client D',
+            'unit_price' => 1000,
+            'start_date' => '2026-02-10',
+            'end_date' => '2026-02-01',
+            'status' => 'contact',
+        ];
+
+        $res2 = $this->post(route('projects.store'), $data2);
+        $res2->assertSessionHasErrors(['end_date']);
+    }
+
+    public function test_update_with_invalid_date_format_and_order_returns_errors(): void
+    {
+        $primitives = [
+            'id' => 5,
+            'title' => 'Date Update',
+            'client_name' => 'Client Y',
+            'unit_price' => 1000,
+            'status' => 'contact',
+        ];
+
+        $this->app->bind(\App\Domain\Repositories\ProjectRepositoryInterface::class, fn () => $this->makeInMemoryRepository([$primitives]));
+
+        // invalid format
+        $data1 = [
+            'title' => 'Dated',
+            'client_name' => 'Client Y',
+            'unit_price' => 1000,
+            'start_date' => '32-99-99',
+            'end_date' => '2026-02-02',
+            'status' => 'contact',
+        ];
+
+        $res1 = $this->put(route('projects.update', $primitives['id']), $data1);
+        $res1->assertSessionHasErrors(['start_date']);
+
+        // end_date before start_date
+        $data2 = [
+            'title' => 'Bad Order',
+            'client_name' => 'Client Y',
+            'unit_price' => 1000,
+            'start_date' => '2026-03-10',
+            'end_date' => '2026-03-01',
+            'status' => 'contact',
+        ];
+
+        $res2 = $this->put(route('projects.update', $primitives['id']), $data2);
+        $res2->assertSessionHasErrors(['end_date']);
+    }
 }

--- a/tests/Feature/ProjectCrudTest.php
+++ b/tests/Feature/ProjectCrudTest.php
@@ -2,79 +2,10 @@
 
 namespace Tests\Feature;
 
-use App\Application\ViewModels\ProjectViewModel;
 use Tests\TestCase;
 
 class ProjectCrudTest extends TestCase
 {
-    private function fakeCreateUseCase()
-    {
-        return new class
-        {
-            public function execute($dto)
-            {
-                return null;
-            }
-        };
-    }
-
-    private function fakeUpdateUseCase()
-    {
-        return new class
-        {
-            public function execute($dto)
-            {
-                return null;
-            }
-        };
-    }
-
-    private function fakeDeleteUseCase()
-    {
-        return new class
-        {
-            public function execute(int $id): void {}
-        };
-    }
-
-    private function fakeGetUseCase(?array $primitives = null)
-    {
-        return new class($primitives)
-        {
-            private $p;
-            public function __construct($p)
-            {
-                $this->p = $p;
-            }
-            public function execute(int $id)
-            {
-                if (! $this->p) {
-                    return null;
-                }
-
-                return ProjectViewModel::fromPrimitives($this->p);
-            }
-        };
-    }
-
-    private function fakeListUseCase(array $items = [])
-    {
-        return new class($items)
-        {
-            private $items;
-            public function __construct($items)
-            {
-                $this->items = $items;
-            }
-            public function execute(int $perPage = 10)
-            {
-                $collection = collect($this->items);
-
-                return new \Illuminate\Pagination\LengthAwarePaginator($collection, $collection->count(), $perPage);
-            }
-        };
-    }
-
     private function makeInMemoryRepository(array $items = [])
     {
         return new class($items) implements \App\Domain\Repositories\ProjectRepositoryInterface

--- a/tests/Feature/ProjectCrudTest.php
+++ b/tests/Feature/ProjectCrudTest.php
@@ -115,7 +115,7 @@ class ProjectCrudTest extends TestCase
         };
     }
 
-    public function test_index_displays_projects(): void
+    public function test_index_with_projects_can_display_projects(): void
     {
         $pr = [
             'id' => 1,
@@ -137,7 +137,7 @@ class ProjectCrudTest extends TestCase
         $response->assertSee('Client A');
     }
 
-    public function test_create_displays_form(): void
+    public function test_create_page_can_return_form_view(): void
     {
         $response = $this->get(route('projects.create'));
 
@@ -145,7 +145,7 @@ class ProjectCrudTest extends TestCase
         $response->assertSee('問い合わせ');
     }
 
-    public function test_edit_shows_project_and_404_when_missing(): void
+    public function test_edit_with_project_can_show_and_missing_can_return_404(): void
     {
         $primitives = [
             'id' => 10,
@@ -167,7 +167,7 @@ class ProjectCrudTest extends TestCase
         $res2->assertStatus(404);
     }
 
-    public function test_destroy_returns_404_when_missing(): void
+    public function test_destroy_with_missing_can_return_404(): void
     {
         $this->app->bind(\App\Domain\Repositories\ProjectRepositoryInterface::class, fn () => $this->makeInMemoryRepository([]));
 
@@ -175,7 +175,7 @@ class ProjectCrudTest extends TestCase
         $res->assertStatus(404);
     }
 
-    public function test_store_creates_project(): void
+    public function test_store_with_valid_data_can_create_project(): void
     {
         $this->app->bind(\App\Domain\Repositories\ProjectRepositoryInterface::class, fn () => $this->makeInMemoryRepository());
 
@@ -210,7 +210,7 @@ class ProjectCrudTest extends TestCase
         $response->assertSessionHasErrors(['title', 'client_name', 'unit_price', 'status']);
     }
 
-    public function test_update_updates_project(): void
+    public function test_update_with_valid_data_can_update_project(): void
     {
         $primitives = [
             'id' => 2,
@@ -234,7 +234,7 @@ class ProjectCrudTest extends TestCase
         $response->assertRedirect(route('projects.index'));
     }
 
-    public function test_destroy_deletes_project(): void
+    public function test_destroy_with_existing_project_can_delete_and_redirect(): void
     {
         $primitives = [
             'id' => 3,

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,5 +6,7 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    //
+    use CreatesApplication;
+
+    // Base test case for Feature/Unit tests
 }

--- a/tests/Unit/Application/CreateProjectUseCaseTest.php
+++ b/tests/Unit/Application/CreateProjectUseCaseTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Unit\Application;
+
+use App\Application\DTOs\ProjectCreateDTO;
+use App\Application\UseCases\CreateProjectUseCase;
+use App\Domain\Models\Project as DomainProject;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+
+class CreateProjectUseCaseTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_execute_with_valid_dto_can_save_and_return_domain_project(): void
+    {
+        $data = [
+            'title' => 'New Project',
+            'client_name' => 'Client B',
+            'unit_price' => 5000,
+            'start_date' => '2026-02-01',
+            'end_date' => '2026-02-10',
+            'status' => 'contact',
+            'memo' => 'created by test',
+            'user_id' => null,
+        ];
+
+        $dto = ProjectCreateDTO::fromArray($data);
+
+        $repoMock = Mockery::mock(\App\Domain\Repositories\ProjectRepositoryInterface::class);
+
+        $repoMock->shouldReceive('save')
+            ->withArgs(function ($arg) use ($data) {
+                if (! $arg instanceof DomainProject) {
+                    return false;
+                }
+
+                $p = $arg->toPrimitives();
+
+                return $p['title'] === $data['title']
+                    && $p['client_name'] === $data['client_name']
+                    && $p['unit_price'] === $data['unit_price'];
+            })
+            ->andReturnUsing(function ($arg) {
+                return $arg; // return the domain object
+            });
+
+        $useCase = new CreateProjectUseCase($repoMock);
+
+        $result = $useCase->execute($dto);
+
+        $this->assertInstanceOf(DomainProject::class, $result);
+        $this->assertSame('New Project', $result->title());
+    }
+}

--- a/tests/Unit/Application/DeleteProjectUseCaseTest.php
+++ b/tests/Unit/Application/DeleteProjectUseCaseTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Tests\Unit\Application;
+
+use App\Application\UseCases\DeleteProjectUseCase;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+
+class DeleteProjectUseCaseTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_execute_with_id_can_call_repository_delete(): void
+    {
+        $repoMock = Mockery::mock(\App\Domain\Repositories\ProjectRepositoryInterface::class);
+        $repoMock->shouldReceive('delete')->with(9)->once();
+
+        $useCase = new DeleteProjectUseCase($repoMock);
+        $useCase->execute(9);
+
+        $this->addToAssertionCount(1);
+    }
+}

--- a/tests/Unit/Application/GetProjectUseCaseTest.php
+++ b/tests/Unit/Application/GetProjectUseCaseTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Unit\Application;
+
+use App\Application\UseCases\GetProjectUseCase;
+use App\Application\ViewModels\ProjectViewModel;
+use App\Domain\Models\Project as DomainProject;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+
+class GetProjectUseCaseTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_execute_with_existing_project_returns_viewmodel(): void
+    {
+        $primitives = [
+            'id' => 11,
+            'title' => 'Fetch Me',
+            'client_name' => 'Client X',
+            'unit_price' => 1200,
+            'start_date' => '2026-04-01',
+            'end_date' => '2026-04-05',
+            'status' => 'working',
+            'memo' => 'memo',
+            'user_id' => null,
+        ];
+
+        $domain = DomainProject::fromPrimitives($primitives);
+
+        $repoMock = Mockery::mock(\App\Domain\Repositories\ProjectRepositoryInterface::class);
+        $repoMock->shouldReceive('findById')->with(11)->andReturn($domain);
+
+        $useCase = new GetProjectUseCase($repoMock);
+
+        $result = $useCase->execute(11);
+
+        $this->assertInstanceOf(ProjectViewModel::class, $result);
+        $this->assertSame('Fetch Me', $result->title);
+        $this->assertSame('Client X', $result->client_name);
+    }
+
+    public function test_execute_with_missing_project_returns_null(): void
+    {
+        $repoMock = Mockery::mock(\App\Domain\Repositories\ProjectRepositoryInterface::class);
+        $repoMock->shouldReceive('findById')->with(999)->andReturnNull();
+
+        $useCase = new GetProjectUseCase($repoMock);
+
+        $result = $useCase->execute(999);
+
+        $this->assertNull($result);
+    }
+}

--- a/tests/Unit/Application/ListProjectsUseCaseTest.php
+++ b/tests/Unit/Application/ListProjectsUseCaseTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Unit\Application;
+
+use App\Application\UseCases\ListProjectsUseCase;
+use App\Application\ViewModels\ProjectViewModel;
+use App\Domain\Models\Project as DomainProject;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+
+class ListProjectsUseCaseTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_execute_returns_paginator_of_viewmodels(): void
+    {
+        $items = [
+            [
+                'id' => 21,
+                'title' => 'List One',
+                'client_name' => 'Client L1',
+                'unit_price' => 1000,
+                'start_date' => '2026-05-01',
+                'end_date' => '2026-05-02',
+                'status' => 'contact',
+                'memo' => null,
+                'user_id' => null,
+            ],
+            [
+                'id' => 22,
+                'title' => 'List Two',
+                'client_name' => 'Client L2',
+                'unit_price' => 2000,
+                'start_date' => '2026-06-01',
+                'end_date' => '2026-06-03',
+                'status' => 'working',
+                'memo' => null,
+                'user_id' => null,
+            ],
+        ];
+
+        $domainCollection = collect(array_map(fn ($p) => DomainProject::fromPrimitives($p), $items));
+
+        $paginator = new LengthAwarePaginator($domainCollection, $domainCollection->count(), 10);
+
+        $repoMock = Mockery::mock(\App\Domain\Repositories\ProjectRepositoryInterface::class);
+        $repoMock->shouldReceive('paginate')->with(10)->andReturn($paginator);
+
+        $useCase = new ListProjectsUseCase($repoMock);
+        $result = $useCase->execute(10);
+
+        $this->assertInstanceOf(\Illuminate\Contracts\Pagination\Paginator::class, $result);
+        $this->assertCount(2, $result->getCollection());
+
+        foreach ($result->getCollection() as $vm) {
+            $this->assertInstanceOf(ProjectViewModel::class, $vm);
+        }
+    }
+}

--- a/tests/Unit/Application/UpdateProjectUseCaseTest.php
+++ b/tests/Unit/Application/UpdateProjectUseCaseTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Unit\Application;
+
+use App\Application\DTOs\ProjectUpdateDTO;
+use App\Application\UseCases\UpdateProjectUseCase;
+use App\Domain\Models\Project as DomainProject;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+
+class UpdateProjectUseCaseTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_execute_with_valid_dto_can_save_and_return_domain_project(): void
+    {
+        $data = [
+            'id' => 5,
+            'title' => 'Updated Project',
+            'client_name' => 'Client U',
+            'unit_price' => 2000,
+            'start_date' => '2026-03-01',
+            'end_date' => '2026-03-10',
+            'status' => 'working',
+            'memo' => 'updated',
+            'user_id' => null,
+        ];
+
+        $dto = ProjectUpdateDTO::fromArray($data);
+
+        $repoMock = Mockery::mock(\App\Domain\Repositories\ProjectRepositoryInterface::class);
+
+        $repoMock->shouldReceive('save')
+            ->withArgs(function ($arg) use ($data) {
+                if (! $arg instanceof DomainProject) {
+                    return false;
+                }
+                $p = $arg->toPrimitives();
+
+                return $p['id'] === $data['id'] && $p['title'] === $data['title'];
+            })
+            ->andReturnUsing(fn ($arg) => $arg);
+
+        $useCase = new UpdateProjectUseCase($repoMock);
+
+        $result = $useCase->execute($dto);
+
+        $this->assertInstanceOf(DomainProject::class, $result);
+        $this->assertSame(5, $result->id());
+        $this->assertSame('Updated Project', $result->title());
+    }
+}

--- a/tests/Unit/DomainProjectTest.php
+++ b/tests/Unit/DomainProjectTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 class DomainProjectTest extends TestCase
 {
-    public function test_calculate_revenue_with_period(): void
+    public function test_calculate_revenue_with_period_can_return_total_revenue(): void
     {
         $start = new DateTimeImmutable('2026-01-01');
         $end = new DateTimeImmutable('2026-01-05');
@@ -18,20 +18,20 @@ class DomainProjectTest extends TestCase
         $this->assertSame(5000, $project->calculateRevenue());
     }
 
-    public function test_calculate_revenue_without_period_returns_zero(): void
+    public function test_calculate_revenue_without_period_can_return_zero(): void
     {
         $project = new Project(null, 't', 'c', 1000, null, null, ProjectStatus::from('contact'), null, null);
         $this->assertSame(0, $project->calculateRevenue());
     }
 
-    public function test_change_status_allows_forward_transition(): void
+    public function test_change_status_forward_transition_can_succeed(): void
     {
         $project = new Project(null, 't', 'c', 1000, null, null, ProjectStatus::from('contact'), null, null);
         $project->changeStatus(ProjectStatus::from('negotiation'));
         $this->assertSame('negotiation', $project->toPrimitives()['status']);
     }
 
-    public function test_change_status_disallows_backward(): void
+    public function test_change_status_backward_transition_can_throw_exception(): void
     {
         $this->expectException(\DomainException::class);
         $project = new Project(null, 't', 'c', 1000, null, null, ProjectStatus::from('working'), null, null);

--- a/tests/Unit/DomainProjectTest.php
+++ b/tests/Unit/DomainProjectTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Domain\Models\Project;
+use App\Domain\ValueObjects\ProjectStatus;
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+
+class DomainProjectTest extends TestCase
+{
+    public function test_calculate_revenue_with_period(): void
+    {
+        $start = new DateTimeImmutable('2026-01-01');
+        $end = new DateTimeImmutable('2026-01-05');
+        $project = new Project(null, 't', 'c', 1000, $start, $end, ProjectStatus::from('working'), null, null);
+
+        $this->assertSame(5000, $project->calculateRevenue());
+    }
+
+    public function test_calculate_revenue_without_period_returns_zero(): void
+    {
+        $project = new Project(null, 't', 'c', 1000, null, null, ProjectStatus::from('contact'), null, null);
+        $this->assertSame(0, $project->calculateRevenue());
+    }
+
+    public function test_change_status_allows_forward_transition(): void
+    {
+        $project = new Project(null, 't', 'c', 1000, null, null, ProjectStatus::from('contact'), null, null);
+        $project->changeStatus(ProjectStatus::from('negotiation'));
+        $this->assertSame('negotiation', $project->toPrimitives()['status']);
+    }
+
+    public function test_change_status_disallows_backward(): void
+    {
+        $this->expectException(\DomainException::class);
+        $project = new Project(null, 't', 'c', 1000, null, null, ProjectStatus::from('working'), null, null);
+        $project->changeStatus(ProjectStatus::from('negotiation'));
+    }
+}

--- a/tests/Unit/EloquentProjectRepositoryTest.php
+++ b/tests/Unit/EloquentProjectRepositoryTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Domain\Models\Project as DomainProject;
+use App\Infrastructure\Repositories\EloquentProjectRepository;
+use DateTimeImmutable;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+
+class EloquentProjectRepositoryTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_find_by_id_maps_to_domain(): void
+    {
+        $m = new \stdClass;
+        $m->id = 42;
+        $m->title = 'Repo Title';
+        $m->client_name = 'Repo Client';
+        $m->unit_price = 2500;
+        $m->start_date = new DateTimeImmutable('2026-01-01');
+        $m->end_date = null;
+        $m->status = 'contact';
+        $m->memo = 'memo';
+        $m->user_id = null;
+
+        $mock = Mockery::mock('alias:App\\Models\\Project');
+        $mock->shouldReceive('find')->with(42)->andReturn($m);
+
+        $repo = new EloquentProjectRepository;
+        $domain = $repo->findById(42);
+
+        $this->assertInstanceOf(DomainProject::class, $domain);
+        $this->assertSame(42, $domain->id());
+    }
+
+    public function test_delete_calls_destroy(): void
+    {
+        $mock = Mockery::mock('alias:App\\Models\\Project');
+        $mock->shouldReceive('destroy')->with(99)->once();
+
+        $repo = new EloquentProjectRepository;
+        $repo->delete(99);
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function test_paginate_transforms_models_to_domain(): void
+    {
+        $m = new \stdClass;
+        $m->id = 5;
+        $m->title = 'P1';
+        $m->client_name = 'C1';
+        $m->unit_price = 1000;
+        $m->start_date = new DateTimeImmutable('2026-01-01');
+        $m->end_date = null;
+        $m->status = 'contact';
+        $m->memo = null;
+        $m->user_id = null;
+
+        $collection = collect([$m]);
+        $paginator = new LengthAwarePaginator($collection, 1, 10);
+
+        $orderMock = Mockery::mock();
+        $orderMock->shouldReceive('paginate')->with(10)->andReturn($paginator);
+
+        $mock = Mockery::mock('alias:App\\Models\\Project');
+        $mock->shouldReceive('orderBy')->with('created_at', 'desc')->andReturn($orderMock);
+
+        $repo = new EloquentProjectRepository;
+        $p = $repo->paginate(10);
+
+        $this->assertInstanceOf(\Illuminate\Contracts\Pagination\Paginator::class, $p);
+        $this->assertSame(1, $p->total());
+    }
+}

--- a/tests/Unit/EloquentProjectRepositoryTest.php
+++ b/tests/Unit/EloquentProjectRepositoryTest.php
@@ -4,95 +4,97 @@ namespace Tests\Unit;
 
 use App\Domain\Models\Project as DomainProject;
 use App\Infrastructure\Repositories\EloquentProjectRepository;
-use DateTimeImmutable;
-use Illuminate\Pagination\LengthAwarePaginator;
-use Mockery;
-use PHPUnit\Framework\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
 
 class EloquentProjectRepositoryTest extends TestCase
 {
-    protected function tearDown(): void
-    {
-        Mockery::close();
-        parent::tearDown();
-    }
+    use RefreshDatabase;
 
     public function test_find_by_id_with_existing_id_can_return_domain_project(): void
     {
-        $m = new \stdClass;
-        $m->id = 42;
-        $m->title = 'Repo Title';
-        $m->client_name = 'Repo Client';
-        $m->unit_price = 2500;
-        $m->start_date = new DateTimeImmutable('2026-01-01');
-        $m->end_date = null;
-        $m->status = 'contact';
-        $m->memo = 'memo';
-        $m->user_id = null;
+        $primitives = [
+            'id' => null,
+            'title' => 'Repo Title',
+            'client_name' => 'Repo Client',
+            'unit_price' => 2500,
+            'start_date' => '2026-01-01',
+            'end_date' => null,
+            'status' => 'contact',
+            'memo' => 'memo',
+            'user_id' => null,
+        ];
 
-        $mock = Mockery::mock('alias:App\\Models\\Project');
-        $mock->shouldReceive('find')->with(42)->andReturn($m);
+        $domain = DomainProject::fromPrimitives($primitives);
 
         $repo = new EloquentProjectRepository;
-        $domain = $repo->findById(42);
+        $saved = $repo->save($domain);
 
-        $this->assertInstanceOf(DomainProject::class, $domain);
-        $this->assertSame(42, $domain->id());
+        $this->assertNotNull($saved->id());
+
+        $found = $repo->findById($saved->id());
+        $this->assertInstanceOf(DomainProject::class, $found);
+        $this->assertSame($saved->id(), $found->id());
     }
 
     public function test_delete_with_existing_id_can_call_destroy(): void
     {
-        $mock = Mockery::mock('alias:App\\Models\\Project');
-        $mock->shouldReceive('destroy')->with(99)->once();
+        $domain = DomainProject::fromPrimitives([
+            'id' => null,
+            'title' => 'ToDelete',
+            'client_name' => 'C',
+            'unit_price' => 1000,
+            'start_date' => '2026-01-01',
+            'end_date' => null,
+            'status' => 'contact',
+            'memo' => null,
+            'user_id' => null,
+        ]);
 
         $repo = new EloquentProjectRepository;
-        $repo->delete(99);
+        $saved = $repo->save($domain);
 
-        $this->addToAssertionCount(1);
+        $repo->delete($saved->id());
+        $this->assertNull($repo->findById($saved->id()));
     }
 
     public function test_paginate_can_transform_models_to_domain(): void
     {
-        $m = new \stdClass;
-        $m->id = 5;
-        $m->title = 'P1';
-        $m->client_name = 'C1';
-        $m->unit_price = 1000;
-        $m->start_date = new DateTimeImmutable('2026-01-01');
-        $m->end_date = null;
-        $m->status = 'contact';
-        $m->memo = null;
-        $m->user_id = null;
-
-        $collection = collect([$m]);
-        $paginator = new LengthAwarePaginator($collection, 1, 10);
-
-        $orderMock = Mockery::mock();
-        $orderMock->shouldReceive('paginate')->with(10)->andReturn($paginator);
-
-        $mock = Mockery::mock('alias:App\\Models\\Project');
-        $mock->shouldReceive('orderBy')->with('created_at', 'desc')->andReturn($orderMock);
-
         $repo = new EloquentProjectRepository;
+
+        for ($i = 1; $i <= 3; $i++) {
+            $repo->save(DomainProject::fromPrimitives([
+                'id' => null,
+                'title' => "P{$i}",
+                'client_name' => "C{$i}",
+                'unit_price' => 1000 * $i,
+                'start_date' => '2026-01-01',
+                'end_date' => null,
+                'status' => 'contact',
+                'memo' => null,
+                'user_id' => null,
+            ]));
+        }
+
         $p = $repo->paginate(10);
 
         $this->assertInstanceOf(\Illuminate\Contracts\Pagination\Paginator::class, $p);
-        $this->assertSame(1, $p->total());
+        $this->assertSame(3, $p->total());
+        $this->assertInstanceOf(DomainProject::class, $p->items()[0]);
     }
 
     public function test_find_by_id_with_missing_id_can_return_null(): void
     {
-        $mock = Mockery::mock('alias:App\\Models\\Project');
-        $mock->shouldReceive('find')->with(123)->andReturn(null);
-
         $repo = new EloquentProjectRepository;
-        $this->assertNull($repo->findById(123));
+        $this->assertNull($repo->findById(123456789));
     }
 
     public function test_save_with_existing_model_can_return_domain_project(): void
     {
-        $primitives = [
-            'id' => 7,
+        $repo = new EloquentProjectRepository;
+
+        $domain = DomainProject::fromPrimitives([
+            'id' => null,
             'title' => 'Updated',
             'client_name' => 'C',
             'unit_price' => 2000,
@@ -101,51 +103,28 @@ class EloquentProjectRepositoryTest extends TestCase
             'status' => 'working',
             'memo' => 'm',
             'user_id' => null,
-        ];
+        ]);
 
-        $domain = DomainProject::fromPrimitives($primitives);
+        $saved = $repo->save($domain);
 
-        $modelInstance = new class
-        {
-            public $id = 7;
-            public $title;
-            public $client_name;
-            public $unit_price;
-            public $start_date;
-            public $end_date;
-            public $status;
-            public $memo;
-            public $user_id;
+        $this->assertInstanceOf(DomainProject::class, $saved);
 
-            public function fill($data)
-            {
-                foreach ($data as $k => $v) {
-                    $this->$k = $v;
-                }
-            }
+        // Update and save again
+        $updatedDomain = DomainProject::fromPrimitives([
+            'id' => $saved->id(),
+            'title' => 'Updated2',
+            'client_name' => 'C2',
+            'unit_price' => 2500,
+            'start_date' => '2026-01-01',
+            'end_date' => null,
+            'status' => 'working',
+            'memo' => 'm2',
+            'user_id' => null,
+        ]);
 
-            public function save() {}
-        };
+        $result = $repo->save($updatedDomain);
 
-        $saved = new \stdClass;
-        $saved->id = 7;
-        $saved->title = 'Updated';
-        $saved->client_name = 'C';
-        $saved->unit_price = 2000;
-        $saved->start_date = new DateTimeImmutable('2026-01-01');
-        $saved->end_date = null;
-        $saved->status = 'working';
-        $saved->memo = 'm';
-        $saved->user_id = null;
-
-        $mock = Mockery::mock('alias:App\\Models\\Project');
-        $mock->shouldReceive('find')->with(7)->andReturn($modelInstance, $saved);
-
-        $repo = new EloquentProjectRepository;
-        $result = $repo->save($domain);
-
-        $this->assertInstanceOf(DomainProject::class, $result);
-        $this->assertSame(7, $result->id());
-        $this->assertSame('Updated', $result->title());
+        $this->assertSame($saved->id(), $result->id());
+        $this->assertSame('Updated2', $result->title());
     }
 }

--- a/tests/Unit/EloquentProjectRepositoryTest.php
+++ b/tests/Unit/EloquentProjectRepositoryTest.php
@@ -17,7 +17,7 @@ class EloquentProjectRepositoryTest extends TestCase
         parent::tearDown();
     }
 
-    public function test_find_by_id_maps_to_domain(): void
+    public function test_find_by_id_with_existing_id_can_return_domain_project(): void
     {
         $m = new \stdClass;
         $m->id = 42;
@@ -40,7 +40,7 @@ class EloquentProjectRepositoryTest extends TestCase
         $this->assertSame(42, $domain->id());
     }
 
-    public function test_delete_calls_destroy(): void
+    public function test_delete_with_existing_id_can_call_destroy(): void
     {
         $mock = Mockery::mock('alias:App\\Models\\Project');
         $mock->shouldReceive('destroy')->with(99)->once();
@@ -51,7 +51,7 @@ class EloquentProjectRepositoryTest extends TestCase
         $this->addToAssertionCount(1);
     }
 
-    public function test_paginate_transforms_models_to_domain(): void
+    public function test_paginate_can_transform_models_to_domain(): void
     {
         $m = new \stdClass;
         $m->id = 5;
@@ -80,7 +80,7 @@ class EloquentProjectRepositoryTest extends TestCase
         $this->assertSame(1, $p->total());
     }
 
-    public function test_find_by_id_returns_null_when_not_found(): void
+    public function test_find_by_id_with_missing_id_can_return_null(): void
     {
         $mock = Mockery::mock('alias:App\\Models\\Project');
         $mock->shouldReceive('find')->with(123)->andReturn(null);
@@ -89,7 +89,7 @@ class EloquentProjectRepositoryTest extends TestCase
         $this->assertNull($repo->findById(123));
     }
 
-    public function test_save_updates_existing_model_and_returns_domain(): void
+    public function test_save_with_existing_model_can_return_domain_project(): void
     {
         $primitives = [
             'id' => 7,

--- a/tests/Unit/EloquentProjectRepositoryTest.php
+++ b/tests/Unit/EloquentProjectRepositoryTest.php
@@ -79,4 +79,73 @@ class EloquentProjectRepositoryTest extends TestCase
         $this->assertInstanceOf(\Illuminate\Contracts\Pagination\Paginator::class, $p);
         $this->assertSame(1, $p->total());
     }
+
+    public function test_find_by_id_returns_null_when_not_found(): void
+    {
+        $mock = Mockery::mock('alias:App\\Models\\Project');
+        $mock->shouldReceive('find')->with(123)->andReturn(null);
+
+        $repo = new EloquentProjectRepository;
+        $this->assertNull($repo->findById(123));
+    }
+
+    public function test_save_updates_existing_model_and_returns_domain(): void
+    {
+        $primitives = [
+            'id' => 7,
+            'title' => 'Updated',
+            'client_name' => 'C',
+            'unit_price' => 2000,
+            'start_date' => '2026-01-01',
+            'end_date' => null,
+            'status' => 'working',
+            'memo' => 'm',
+            'user_id' => null,
+        ];
+
+        $domain = DomainProject::fromPrimitives($primitives);
+
+        $modelInstance = new class
+        {
+            public $id = 7;
+            public $title;
+            public $client_name;
+            public $unit_price;
+            public $start_date;
+            public $end_date;
+            public $status;
+            public $memo;
+            public $user_id;
+
+            public function fill($data)
+            {
+                foreach ($data as $k => $v) {
+                    $this->$k = $v;
+                }
+            }
+
+            public function save() {}
+        };
+
+        $saved = new \stdClass;
+        $saved->id = 7;
+        $saved->title = 'Updated';
+        $saved->client_name = 'C';
+        $saved->unit_price = 2000;
+        $saved->start_date = new DateTimeImmutable('2026-01-01');
+        $saved->end_date = null;
+        $saved->status = 'working';
+        $saved->memo = 'm';
+        $saved->user_id = null;
+
+        $mock = Mockery::mock('alias:App\\Models\\Project');
+        $mock->shouldReceive('find')->with(7)->andReturn($modelInstance, $saved);
+
+        $repo = new EloquentProjectRepository;
+        $result = $repo->save($domain);
+
+        $this->assertInstanceOf(DomainProject::class, $result);
+        $this->assertSame(7, $result->id());
+        $this->assertSame('Updated', $result->title());
+    }
 }

--- a/tests/Unit/ExampleTest.php
+++ b/tests/Unit/ExampleTest.php
@@ -9,7 +9,7 @@ class ExampleTest extends TestCase
     /**
      * A basic test example.
      */
-    public function test_that_true_is_true(): void
+    public function test_dummy_assertion_can_be_true(): void
     {
         $this->assertTrue(true);
     }

--- a/tests/Unit/ProjectModelExtrasTest.php
+++ b/tests/Unit/ProjectModelExtrasTest.php
@@ -9,19 +9,19 @@ use PHPUnit\Framework\TestCase;
 
 class ProjectModelExtrasTest extends TestCase
 {
-    public function test_constructor_validations_empty_title_throws(): void
+    public function test_constructor_with_empty_title_can_throw_exception(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         new Project(null, '', 'c', 1000, null, null, ProjectStatus::from('contact'), null, null);
     }
 
-    public function test_constructor_negative_unit_price_throws(): void
+    public function test_constructor_with_negative_unit_price_can_throw_exception(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         new Project(null, 't', 'c', -10, null, null, ProjectStatus::from('contact'), null, null);
     }
 
-    public function test_constructor_start_after_end_throws(): void
+    public function test_constructor_with_start_after_end_can_throw_exception(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $start = new DateTimeImmutable('2026-02-10');
@@ -29,7 +29,7 @@ class ProjectModelExtrasTest extends TestCase
         new Project(null, 't', 'c', 1000, $start, $end, ProjectStatus::from('contact'), null, null);
     }
 
-    public function test_calculate_revenue_monthly(): void
+    public function test_calculate_revenue_with_monthly_unit_can_return_total(): void
     {
         $start = new DateTimeImmutable('2026-01-15');
         $end = new DateTimeImmutable('2026-03-14');
@@ -39,7 +39,7 @@ class ProjectModelExtrasTest extends TestCase
         $this->assertSame(3000, $project->calculateRevenue('monthly'));
     }
 
-    public function test_calculate_revenue_unknown_unit_throws(): void
+    public function test_calculate_revenue_with_unknown_unit_can_throw_exception(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $start = new DateTimeImmutable('2026-01-01');
@@ -49,7 +49,7 @@ class ProjectModelExtrasTest extends TestCase
         $project->calculateRevenue('yearly');
     }
 
-    public function test_to_primitives_and_getters(): void
+    public function test_to_primitives_and_getters_can_return_expected_values(): void
     {
         $start = new DateTimeImmutable('2026-01-01');
         $end = new DateTimeImmutable('2026-01-01');
@@ -60,6 +60,6 @@ class ProjectModelExtrasTest extends TestCase
         $this->assertSame('Title X', $project->title());
         $this->assertSame('Title X', $pr['title']);
         $this->assertSame('2026-01-01', $pr['start_date']);
-        $this->assertSame(2000, $pr['unit_price']);
+        $this->assertSame(2000, $pr->unit_price);
     }
 }

--- a/tests/Unit/ProjectModelExtrasTest.php
+++ b/tests/Unit/ProjectModelExtrasTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Domain\Models\Project;
+use App\Domain\ValueObjects\ProjectStatus;
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+
+class ProjectModelExtrasTest extends TestCase
+{
+    public function test_constructor_validations_empty_title_throws(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        new Project(null, '', 'c', 1000, null, null, ProjectStatus::from('contact'), null, null);
+    }
+
+    public function test_constructor_negative_unit_price_throws(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        new Project(null, 't', 'c', -10, null, null, ProjectStatus::from('contact'), null, null);
+    }
+
+    public function test_constructor_start_after_end_throws(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $start = new DateTimeImmutable('2026-02-10');
+        $end = new DateTimeImmutable('2026-02-01');
+        new Project(null, 't', 'c', 1000, $start, $end, ProjectStatus::from('contact'), null, null);
+    }
+
+    public function test_calculate_revenue_monthly(): void
+    {
+        $start = new DateTimeImmutable('2026-01-15');
+        $end = new DateTimeImmutable('2026-03-14');
+        $project = new Project(null, 't', 'c', 1000, $start, $end, ProjectStatus::from('working'), null, null);
+
+        // Jan, Feb, Mar => 3 months
+        $this->assertSame(3000, $project->calculateRevenue('monthly'));
+    }
+
+    public function test_calculate_revenue_unknown_unit_throws(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $start = new DateTimeImmutable('2026-01-01');
+        $end = new DateTimeImmutable('2026-01-05');
+        $project = new Project(null, 't', 'c', 1000, $start, $end, ProjectStatus::from('working'), null, null);
+
+        $project->calculateRevenue('yearly');
+    }
+
+    public function test_to_primitives_and_getters(): void
+    {
+        $start = new DateTimeImmutable('2026-01-01');
+        $end = new DateTimeImmutable('2026-01-01');
+        $project = new Project(7, 'Title X', 'Client X', 2000, $start, $end, ProjectStatus::from('contact'), 'note', 12);
+
+        $pr = $project->toPrimitives();
+        $this->assertSame(7, $project->id());
+        $this->assertSame('Title X', $project->title());
+        $this->assertSame('Title X', $pr['title']);
+        $this->assertSame('2026-01-01', $pr['start_date']);
+        $this->assertSame(2000, $pr['unit_price']);
+    }
+}

--- a/tests/Unit/ProjectModelExtrasTest.php
+++ b/tests/Unit/ProjectModelExtrasTest.php
@@ -60,6 +60,6 @@ class ProjectModelExtrasTest extends TestCase
         $this->assertSame('Title X', $project->title());
         $this->assertSame('Title X', $pr['title']);
         $this->assertSame('2026-01-01', $pr['start_date']);
-        $this->assertSame(2000, $pr->unit_price);
+        $this->assertSame(2000, $pr['unit_price']);
     }
 }

--- a/tests/Unit/ProjectStatusTest.php
+++ b/tests/Unit/ProjectStatusTest.php
@@ -7,13 +7,13 @@ use PHPUnit\Framework\TestCase;
 
 class ProjectStatusTest extends TestCase
 {
-    public function test_from_invalid_throws(): void
+    public function test_from_with_invalid_value_can_throw_exception(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         ProjectStatus::from('not_a_status');
     }
 
-    public function test_label_value_equals_and_tostring(): void
+    public function test_value_label_equals_and_to_string_can_work(): void
     {
         $s = ProjectStatus::from('working');
         $this->assertSame('working', $s->value());

--- a/tests/Unit/ProjectStatusTest.php
+++ b/tests/Unit/ProjectStatusTest.php
@@ -13,12 +13,31 @@ class ProjectStatusTest extends TestCase
         ProjectStatus::from('not_a_status');
     }
 
-    public function test_value_label_equals_and_to_string_can_work(): void
+    public function test_value_with_working_can_return_working(): void
     {
         $s = ProjectStatus::from('working');
+
         $this->assertSame('working', $s->value());
+    }
+
+    public function test_label_with_working_can_return_japanese_label(): void
+    {
+        $s = ProjectStatus::from('working');
+
         $this->assertSame('稼働中', $s->label());
+    }
+
+    public function test_equals_with_same_value_can_return_true(): void
+    {
+        $s = ProjectStatus::from('working');
+
         $this->assertTrue($s->equals(ProjectStatus::from('working')));
+    }
+
+    public function test_to_string_with_working_can_return_value_string(): void
+    {
+        $s = ProjectStatus::from('working');
+
         $this->assertSame('working', (string) $s);
     }
 }

--- a/tests/Unit/ProjectStatusTest.php
+++ b/tests/Unit/ProjectStatusTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Domain\ValueObjects\ProjectStatus;
+use PHPUnit\Framework\TestCase;
+
+class ProjectStatusTest extends TestCase
+{
+    public function test_from_invalid_throws(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        ProjectStatus::from('not_a_status');
+    }
+
+    public function test_label_value_equals_and_tostring(): void
+    {
+        $s = ProjectStatus::from('working');
+        $this->assertSame('working', $s->value());
+        $this->assertSame('稼働中', $s->label());
+        $this->assertTrue($s->equals(ProjectStatus::from('working')));
+        $this->assertSame('working', (string) $s);
+    }
+}


### PR DESCRIPTION
## 概要
プロジェクトドメイン、リポジトリ、ステータスロジックに対する包括的なユニットテストおよび機能テストスイートを導入するとともに、テスト環境構成の改善を行います。これらの変更により、アプリケーションロジックが徹底的にテストされ、エッジケースが網羅され、テスト環境が分離され信頼性が高まります。

## 変更内容
**テストスイートの追加と改善:**

* `ProjectCrudTest.php` に、バリデーション、リポジトリバインディング、HTTPエンドポイントチェックを含むプロジェクトCRUD操作の機能テストを追加。
* `DomainProjectTest.php` および `ProjectModelExtrasTest.php` に、収益計算、ステータス遷移、コンストラクタ検証をカバーするプロジェクトドメインモデルのユニットテストを追加。
* `ProjectStatus` 値オブジェクトのユニットテストを追加し、`ProjectStatusTest.php` 内で正しいインスタンス化、ラベリング、等価性チェックを保証。
* Eloquent プロジェクトリポジトリのユニットテストを追加し、`EloquentProjectRepositoryTest.php` 内でモデルからドメインへのマッピング、削除、ページネーションロジックを検証。

**テスト環境設定:**

* テスト中の分離と速度向上のため、`phpunit.xml` を更新しインメモリ SQLite データベースを使用するように変更。
* `CreatesApplication` トレイトを導入し、ベース `TestCase` を更新してこれを採用。テスト用アプリケーションのブートストラップを標準化。
## Issue管理
closes #6 

※ このPull Requestの説明およびレビューは日本語で記載してください。